### PR TITLE
Add crawler depends

### DIFF
--- a/crawler/setup.cfg
+++ b/crawler/setup.cfg
@@ -30,11 +30,16 @@ package_dir =
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires = pyscaffold>=3.3a0,<4
 # Add here dependencies of your project (semicolon/line-separated), e.g.
-# install_requires = numpy; scipy
+install_requires = numpy
+                    nltk
+                    pytest
+                    typing
+                    rake-nltk
+                    pdfplumber
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-# python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+python_requires = >=3.8
 
 [options.packages.find]
 where = src
@@ -72,7 +77,6 @@ extras = True
 # e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
 # in order to write a coverage file that can be read by Jenkins.
 addopts =
-    --cov crawler --cov-report term-missing
     --verbose
 norecursedirs =
     dist

--- a/crawler/src/crawler/crawl_pdf.py
+++ b/crawler/src/crawler/crawl_pdf.py
@@ -8,8 +8,6 @@ import logging
 from pathlib import Path
 from typing import DefaultDict, List, Text
 import pdfplumber
-import pandas as pd
-
 
 __author__ = "Blake Vente"
 __copyright__ = "Blake Vente"

--- a/crawler/tests/test_index_generator.py
+++ b/crawler/tests/test_index_generator.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import json
 from crawler.index_generator import IndexGenerator, SyllabusIndexEntry
 from pathlib import Path
 
@@ -18,6 +19,8 @@ def test_index_generator():
     attrs_in_record = {"course_id", "tags", "urls"}
     assert "course_id" in first
     assert set(first).issuperset(attrs_in_record)
+    with open("processed_index.json.orig", "w") as outfile:
+        json.dump(index, outfile, indent=4)
 
 
 def test_syllabus_index_entry():


### PR DESCRIPTION
Now developers only need to do `python setup.py develop` to get dependencies. All further depends should be added in `setup.cfg` around line 33.